### PR TITLE
Add start of game logic / design

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -75,6 +75,14 @@
   z-index: 1;
 }
 
+.alert-parent{
+  position: absolute;
+  top: 5%;
+  margin-left: auto;
+  margin-right: auto;
+  z-index: 1;
+}
+
 .youtube-control-button:hover {
   cursor: pointer;
 }
@@ -107,5 +115,4 @@
   margin-right: auto;
   left: 0;
   right: 0;
-  top: 700px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -22,7 +22,7 @@
   justify-content: center;
   font-size: calc(10px + 2vmin);
   color: white;
-  
+
 }
 
 .App-link {
@@ -33,34 +33,23 @@
   from {
     transform: rotate(0deg);
   }
+
   to {
     transform: rotate(360deg);
   }
 }
 
-.map-area {
-  display: flex;
-  justify-content: center;
-  flex-direction: row;
-  flex-wrap: wrap;
-}
-
-.presenter {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  flex-grow: 9999;
-}
-
 .photo {
   position: relative;
+  margin: 0 auto;
+  width: 900px;
 }
 
-.photo:hover{
+.photo:hover {
   cursor: pointer;
 }
 
-.map-controls{
+.map-controls {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -70,42 +59,53 @@
   padding: 10px;
 }
 
-.back-button{
+.back-button {
   position: absolute;
   top: 1%;
   right: 1%;
   z-index: 1;
-  
-} 
+}
 
-.you-text{
+.zone-text {
   position: absolute;
   top: 95%;
   left: 50%;
-  transform: translate(-50%, -50%); 
+  transform: translate(-50%, -50%);
   text-align: center;
   z-index: 1;
 }
 
-.youtube-control-button:hover{
+.youtube-control-button:hover {
   cursor: pointer;
 }
 
-.game-started{
+.game-started {
   top: 0%;
-  left: 0%;
   z-index: 2;
   position: absolute;
-  background-color: rgba(0,0,0,0.5);
+  background-color: rgba(0, 0, 0, 0.5);
+  margin-left: auto;
+  margin-right: auto;
+  left: 0;
+  right: 0;
 }
 
-.instructions{
+.instructions {
   z-index: 1;
   padding-top: 40px;
   color: white;
 }
 
-.start-button{
+.start-button {
   top: 60%;
   z-index: 1;
+}
+
+.youtube-player-parent{
+  position: absolute;
+  margin-left: auto;
+  margin-right: auto;
+  left: 0;
+  right: 0;
+  top: 700px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -90,3 +90,22 @@
 .youtube-control-button:hover{
   cursor: pointer;
 }
+
+.game-started{
+  top: 0%;
+  left: 0%;
+  z-index: 2;
+  position: absolute;
+  background-color: rgba(0,0,0,0.5);
+}
+
+.instructions{
+  z-index: 1;
+  padding-top: 40px;
+  color: white;
+}
+
+.start-button{
+  top: 60%;
+  z-index: 1;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import Header from "./components/Header";
 import "./App.css";
 import { YoutubePlayer } from "./components/YoutubePlayer";
 import StartGame from "./components/StartGame";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import {
   currentQuestionState,
   getNextQuestion,
@@ -27,11 +27,11 @@ function App() {
   const [videoShown, setVideoShown] = useRecoilState(videoShownState);
   const [world, setWorld] = useState<Stack<MapDetails>>(new Stack<MapDetails>(5, AllWorlds));
   const [hoverArea, setHoverArea] = useState<String>();
-  const [result, setResult] = useState<String>();
-  const [answer, setAnswer] = useState<String>("");
-  const [gameStarted, ] = useRecoilState(gameStartedState);
+  const [result, setResult] = useState<Boolean>();
+  const [answer, setAnswer] = useState<String|undefined>();
+  const gameStarted = useRecoilValue(gameStartedState);
   const [showAlert, setShowAlert] = useState<Boolean>(false);
-  const [choice, setChoice] = useState<String>("");
+  const [choice, setChoice] = useState<String|undefined>();
 
    let imageMapperProps: ImageMapperProps = {
      src: world.peek().img,
@@ -83,7 +83,8 @@ function App() {
     setShowAlert(false);
     setWorld(new Stack<MapDetails>(5, AllWorlds));
     setVideoShown(true);
-    displayFeedback(choice === currentQuestion.answerName, currentQuestion.answerName);
+    setResult(choice === currentQuestion.answerName);
+    setAnswer(currentQuestion.answerName);
 
     setTimeout(() => {
         setResult(undefined);
@@ -93,15 +94,7 @@ function App() {
     }, 10000);
   
   }
-
-  const displayFeedback = (result: Boolean, answer: String) => {
-    if (result) {
-      setResult("Correct");
-    } else {
-      setResult("Incorrect");
-    }
-    setAnswer(answer);
-  }
+  
 
   const enterArea = (area: MapAreas) => {
     setHoverArea(area.id);
@@ -116,27 +109,24 @@ function App() {
       <Header />
       {(videoShown === true)
       ? <Typography 
-        variant="h6"
-        sx={{
-          fontFamily: 'monospace',
-          padding: 2
-        }}
-      >
-      {result}: {answer}
-      </Typography>
+          variant="h6"
+          sx={{fontFamily: 'monospace', padding: 2}}
+        >
+          {result 
+          ? <span>Correct: {answer}</span>
+          : <span>Incorrect: {answer}</span>
+          }
+        </Typography>
 
-      :  <div className="photo">
+      : <div className="photo">
             <ImageMapper {...imageMapperProps} />
-            {!gameStarted
-              ?<StartGame />
-              :<></> 
-            }
+            {!gameStarted && <StartGame/>}
             <IconButton 
               className="back-button"
               size="medium" 
               sx={{position:"absolute", backgroundColor: "white"}}
               disabled={!!videoShown || world.peek() === AllWorlds} 
-              onClick={() => { removeMap(); }}
+              onClick={removeMap}
               title="Back one map" 
             > 
             <UndoIcon />
@@ -148,8 +138,8 @@ function App() {
                 severity="warning"
                 action={
                   <ButtonGroup>
-                    <Button color="inherit" size="small" onClick={() => {evaluateChoice();}}>YES</Button>
-                    <Button color="inherit" size="small" onClick={() => {removeAlert();}}>NO</Button>
+                    <Button color="inherit" size="small" onClick={evaluateChoice}>YES</Button>
+                    <Button color="inherit" size="small" onClick={removeAlert}>NO</Button>
                   </ButtonGroup>
                 }
               >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,13 @@ import React, { useState } from "react";
 import Header from "./components/Header";
 import "./App.css";
 import { YoutubePlayer } from "./components/YoutubePlayer";
+import StartGame from "./components/StartGame";
 import { useRecoilState } from "recoil";
 import {
   currentQuestionState,
   getNextQuestion,
-  videoShownState
+  videoShownState,
+  gameStartedState
 } from "./state";
 import Typography from "@mui/material/Typography";
 import UndoIcon from '@mui/icons-material/Undo';
@@ -23,6 +25,7 @@ function App() {
   const [world, setWorld] = useState<Stack<MapDetails>>(new Stack<MapDetails>(5, AllWorlds));
   const [hoverArea, setHoverArea] = useState<String>();
   const [result, setResult] = useState<Boolean>();
+  const [gameStarted, ] = useRecoilState(gameStartedState);
 
    let imageMapperProps: ImageMapperProps = {
      src: world.peek().img,
@@ -100,32 +103,35 @@ function App() {
       :<div className="map-area">
         <div className="presenter">
           <div className="photo">
-            <ImageMapper {...imageMapperProps} />
-            <IconButton 
-              className="back-button"
-              size="medium" 
-              sx={{position:"absolute", backgroundColor: "white"}}
-              disabled={!!videoShown || world.peek() === AllWorlds} 
-              onClick={() => { removeMap(); }} 
-            > 
-            <UndoIcon />
-            </IconButton>
-
-            <Typography
-              variant="h6"
-              className="you-text"             
-              sx={{
-                mr: 2,
-                display: { xs: 'none', md: 'flex' },
-                fontFamily: 'monospace',
-                fontWeight: 700,
-                letterSpacing: '.3rem',
-                color: 'white',
-                textDecoration: 'none',
-              }} 
-            >
-            {hoverArea}
-            </Typography>
+              <ImageMapper {...imageMapperProps} />
+              {!gameStarted
+                ?<StartGame />
+                :<></> 
+              }
+              <IconButton 
+                className="back-button"
+                size="medium" 
+                sx={{position:"absolute", backgroundColor: "white"}}
+                disabled={!!videoShown || world.peek() === AllWorlds} 
+                onClick={() => { removeMap(); }} 
+              > 
+              <UndoIcon />
+              </IconButton>
+              <Typography
+                variant="h6"
+                className="you-text"             
+                sx={{
+                  mr: 2,
+                  display: { xs: 'none', md: 'flex' },
+                  fontFamily: 'monospace',
+                  fontWeight: 700,
+                  letterSpacing: '.3rem',
+                  color: 'white',
+                  textDecoration: 'none',
+                }} 
+              >
+              {hoverArea}
+              </Typography>
           </div>
         </div>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,45 +100,44 @@ function App() {
       ? result===true
         ?<h3>Correct!</h3>
         :<h3>Incorrect!</h3>
-      :<div className="map-area">
-        <div className="presenter">
-          <div className="photo">
-              <ImageMapper {...imageMapperProps} />
-              {!gameStarted
-                ?<StartGame />
-                :<></> 
-              }
-              <IconButton 
-                className="back-button"
-                size="medium" 
-                sx={{position:"absolute", backgroundColor: "white"}}
-                disabled={!!videoShown || world.peek() === AllWorlds} 
-                onClick={() => { removeMap(); }} 
-              > 
-              <UndoIcon />
-              </IconButton>
-              <Typography
-                variant="h6"
-                className="you-text"             
-                sx={{
-                  mr: 2,
-                  display: { xs: 'none', md: 'flex' },
-                  fontFamily: 'monospace',
-                  fontWeight: 700,
-                  letterSpacing: '.3rem',
-                  color: 'white',
-                  textDecoration: 'none',
-                }} 
-              >
-              {hoverArea}
-              </Typography>
-          </div>
+
+      :  <div className="photo">
+            <ImageMapper {...imageMapperProps} />
+            {!gameStarted
+              ?<StartGame />
+              :<></> 
+            }
+            <IconButton 
+              className="back-button"
+              size="medium" 
+              sx={{position:"absolute", backgroundColor: "white"}}
+              disabled={!!videoShown || world.peek() === AllWorlds} 
+              onClick={() => { removeMap(); }} 
+            > 
+            <UndoIcon />
+            </IconButton>
+            <Typography
+              variant="h6"
+              className="zone-text"             
+              sx={{
+                mr: 2,
+                display: { xs: 'none', md: 'flex' },
+                fontFamily: 'monospace',
+                fontWeight: 700,
+                letterSpacing: '.3rem',
+                color: 'white',
+                textDecoration: 'none',
+              }} 
+            >
+            {hoverArea}
+            </Typography>
         </div>
-      </div>
       }
 
-      <YoutubePlayer />
-
+      <div className="youtube-player-parent">
+        <YoutubePlayer />
+      </div>
+      
     </div>
   );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Icon, IconProps } from "./Icon";
 
-interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+interface ButtonProps extends React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
   text?: string
   tooltip?: string
   icon?: IconProps['icon']
@@ -15,7 +15,8 @@ export const Button: React.FC<ButtonProps> = ({
   tooltip,
   icon,
   text,
-  highlighted
+  highlighted,
+  disabled
 }) => {
   return (
     <>
@@ -32,6 +33,7 @@ export const Button: React.FC<ButtonProps> = ({
         }}
         className={className}
         title={tooltip}
+        disabled={disabled}
       >
         {icon && <Icon icon={icon} />}
         {text && <span style={{ marginLeft: 8 }}>{text}</span>}

--- a/src/components/StartGame.tsx
+++ b/src/components/StartGame.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import "../App.css";
-import { useRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import Box from '@mui/material/Box';
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
@@ -8,8 +8,8 @@ import { gameStartedState, isPlayingState } from "../state";
 
 
 function StartGame(){
-  const [, setGameStarted] = useRecoilState(gameStartedState);
-  const [, setIsPlaying] = useRecoilState(isPlayingState);
+  const setGameStarted = useSetRecoilState(gameStartedState);
+  const setIsPlaying = useSetRecoilState(isPlayingState);
 
   return (
     <Box 

--- a/src/components/StartGame.tsx
+++ b/src/components/StartGame.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import "../App.css";
+import { useRecoilState } from "recoil";
+import Box from '@mui/material/Box';
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import { gameStartedState, isPlayingState } from "../state";
+
+
+function StartGame(){
+  const [, setGameStarted] = useRecoilState(gameStartedState);
+  const [, setIsPlaying] = useRecoilState(isPlayingState);
+
+  return (
+    <Box 
+      className="game-started"
+      sx={{width: 900, height:600}}
+    >
+      <Typography
+        className="instructions"
+        variant="h6"
+      >
+        Can you guess where in Warcraft you are from the soundtrack alone?<br/>
+        Click the button to find out
+      </Typography>
+      <Button 
+        className="start-button" 
+        color="primary"
+        size="large"
+        variant="contained"
+        onClick={() => { setGameStarted(true); setIsPlaying(true);}}
+      >
+        Start
+      </Button>
+    </Box>
+  )
+}
+
+export default StartGame;

--- a/src/components/YoutubePlayer.tsx
+++ b/src/components/YoutubePlayer.tsx
@@ -12,6 +12,8 @@ import { useRecoilState } from 'recoil';
 import {
   currentQuestionState,
   videoShownState,
+  isPlayingState,
+  gameStartedState
 } from '../state';
 import { worldOfWarcraft } from '../config';
 
@@ -105,9 +107,10 @@ export const YoutubePlayer: React.FC<{soundtrackIndex?: number}> = ({
   // Global State
   const [videoShown] = useRecoilState(videoShownState);
   const [currentQuestion] = useRecoilState(currentQuestionState);
+  const [isPlaying, setIsPlaying] = useRecoilState(isPlayingState);
+  const [gameStarted, ] = useRecoilState(gameStartedState);
 
   // Local State
-  const [isPlaying, setIsPlaying] = useState(true);
   const [totalTime, setTotalTime] = useState<number | undefined>(0);
   const [currentTime, setCurrentTime] = useState<number | undefined>(0);
   const reactPlayerRef = useRef<ReactPlayer>(null);
@@ -115,6 +118,7 @@ export const YoutubePlayer: React.FC<{soundtrackIndex?: number}> = ({
   soundtrackIndex = currentQuestion.answerIndex
   const currentAmbiance = worldOfWarcraft[soundtrackIndex];
 
+  
   const handleRestart = () => {
     reactPlayerRef.current?.seekTo(currentAmbiance.startTimeS || 1, 'seconds');
   };
@@ -175,6 +179,7 @@ export const YoutubePlayer: React.FC<{soundtrackIndex?: number}> = ({
           className="youtube-control-button"
           icon={isPlaying ? 'pause' : 'play'}
           tooltip={isPlaying ? 'pause' : 'play'}
+          disabled={!gameStarted}
           onClick={logEventClickWrapper({
             eventData: { ...logData, actionId: isPlaying ? 'pause' : 'play' },
             onClick: () => setIsPlaying(!isPlaying),
@@ -186,6 +191,7 @@ export const YoutubePlayer: React.FC<{soundtrackIndex?: number}> = ({
               className="youtube-control-button"
               icon="fastForward"
               tooltip="Fast Forward 10m"
+              disabled={!gameStarted}
               onClick={logEventClickWrapper({
                 eventData: { ...logData, actionId: 'fastForward' },
                 onClick: handleFastForward,
@@ -195,6 +201,7 @@ export const YoutubePlayer: React.FC<{soundtrackIndex?: number}> = ({
               className="youtube-control-button"
               icon="restart"
               tooltip="Restart"
+              disabled={!gameStarted}
               onClick={logEventClickWrapper({
                 eventData: { ...logData, actionId: 'restart' },
                 onClick: handleRestart,

--- a/src/components/YoutubePlayer.tsx
+++ b/src/components/YoutubePlayer.tsx
@@ -8,7 +8,7 @@ import { css } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import Button from './Button';
 import { logEventClickWrapper } from '../utils/logEventClickWrapper';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import {
   currentQuestionState,
   videoShownState,
@@ -108,7 +108,7 @@ export const YoutubePlayer: React.FC<{soundtrackIndex?: number}> = ({
   const [videoShown] = useRecoilState(videoShownState);
   const [currentQuestion] = useRecoilState(currentQuestionState);
   const [isPlaying, setIsPlaying] = useRecoilState(isPlayingState);
-  const [gameStarted, ] = useRecoilState(gameStartedState);
+  const gameStarted = useRecoilValue(gameStartedState);
 
   // Local State
   const [totalTime, setTotalTime] = useState<number | undefined>(0);

--- a/src/components/YoutubePlayer.tsx
+++ b/src/components/YoutubePlayer.tsx
@@ -178,7 +178,7 @@ export const YoutubePlayer: React.FC<{soundtrackIndex?: number}> = ({
         <Button
           className="youtube-control-button"
           icon={isPlaying ? 'pause' : 'play'}
-          tooltip={isPlaying ? 'pause' : 'play'}
+          tooltip={isPlaying ? 'Pause' : 'Play'}
           disabled={!gameStarted}
           onClick={logEventClickWrapper({
             eventData: { ...logData, actionId: isPlaying ? 'pause' : 'play' },
@@ -190,7 +190,7 @@ export const YoutubePlayer: React.FC<{soundtrackIndex?: number}> = ({
             <Button
               className="youtube-control-button"
               icon="fastForward"
-              tooltip="Fast Forward 10m"
+              tooltip="Fast forward"
               disabled={!gameStarted}
               onClick={logEventClickWrapper({
                 eventData: { ...logData, actionId: 'fastForward' },

--- a/src/state.ts
+++ b/src/state.ts
@@ -26,3 +26,14 @@ export const currentQuestionState = atom({
   key: "currentQuestion",
   default: getNextQuestion(),
 });
+
+export const gameStartedState = atom({
+  key:"gameStarted",
+  default: false,
+});
+
+export const isPlayingState = atom({
+  key:"isPlaying",
+  default: false,
+});
+


### PR DESCRIPTION
Few small changes for start of game logic: 

- Transparent overlay with game instructions and start game button
This should fix the bug / issue with the browser not liking the auto play music 

- Disable YouTube Player buttons when gameStarted state is false
This required updating our button wrapper to allow for the "disabled" field and new global state, gameStarted

- Move 'isPlaying' state in YoutubePlayer component up to global state, in state.ts
This is so that the new StartGame component can set 'isPlaying' state to true. This will "auto" start the music after a user clicks on the 'start' button in the StartGame component. 

Let me know if you have any design feedback or feedback on the instruction wording! 
